### PR TITLE
Avoid duplicate entries in db table modx_fd_paths

### DIFF
--- a/core/components/filedownloadr/src/FileDownloadR.php
+++ b/core/components/filedownloadr/src/FileDownloadR.php
@@ -704,7 +704,7 @@ class FileDownloadR
 
         $fdlPath = $this->modx->getObject('fdPaths', [
             'ctx' => $file['ctx'],
-            'media_source_id' => $this->getOption('mediaSourceId'),
+            'media_source_id' => $this->getOption('mediaSourceId', [], 0),
             'filename' => $filename,
             'hash' => $this->setHashedParam($file['ctx'], $file['filename'])
         ]);


### PR DESCRIPTION
The code creates duplicate entries for the same file in the database table `modx_fd_paths` when using the snippet "FileDownloadLink".

The problem is, that the column `media_source_id` has a default value of `0`. But when checking whether a file already exists, the code searches for the value `null`.